### PR TITLE
Make radio buttons accessible

### DIFF
--- a/stuff/kakoi-jvotne-vi-kysaiti/index.html
+++ b/stuff/kakoi-jvotne-vi-kysaiti/index.html
@@ -25,7 +25,7 @@
             <p id="results">УЗНАЙТИ КАКОИ ЖВОТНЕ ВЫ ДОСТОЙНЫ КУСАТ</p>
             <div id="question" style="display:none;">
                 <h2>Варианты ответов:</h2>
-                <table><tbody id="options"></tbody></table>
+                <table role="presentation"><tbody id="options"></tbody></table>
             </div>
         </article>
         <button id="mainButton" type="button" class="btn" onclick="startTest();">Пройти тест!</button>

--- a/stuff/kakoi-jvotne-vi-kysaiti/index.html
+++ b/stuff/kakoi-jvotne-vi-kysaiti/index.html
@@ -97,7 +97,7 @@
         {
             let tr = `<tr>
                 <td><input type="radio" name="opt" id="${o}" onclick="mainButton.disabled = false;"></td>
-                <td>${questions[currentQuestion].options[o]}</td>
+                <td><label for="${o}">${questions[currentQuestion].options[o]}</label></td>
                 </tr>`;
             optionsTable.appendChild(htmlToElement(tr));
         }


### PR DESCRIPTION
Wrap radio buttons' names with the semantic [HTML label](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label) element. This is done for two main purposes:
- Helps user with motor impairments by allowing them to click or tap the label which is a larger clickable area than just the button itself
- Helps users with vision impairments who might not understand which radio button corresponds to what label without looking at it by connecting the button to the label semantically 

Also removes table semantics from the layout table (again, beneficial to screen reader users primarily who might accidentally switch to table data mode instead of usual reading mode).